### PR TITLE
fix: Correct timezone bug in alarm command (from UTC to JST)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ multidict==6.0.4
 python-dotenv==1.0.0
 Werkzeug==3.0.0
 yarl==1.9.2
+pytz==2023.3.post1


### PR DESCRIPTION
The previous version of the alarm command used UTC timezone for setting alarms, but it should use JST (Japan Standard Time) as the server timezone. This commit fixes the bug by adjusting the timezone to JST, ensuring that alarms are correctly set in the server's local time.